### PR TITLE
Use serializer context in virtual model

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,4 +12,4 @@ django-virtual-models is maintained by [Vinta Software](https://www.vintasoftwar
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Jackson Alves Sousa (https://github.com/jackson541/)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,7 +69,7 @@ this is how you set up your fork for local development::
 
 4. Install the project and the dev requirements::
 
-    $ pip install -e .[doc,dev,test]
+    $ pip install -e ".[doc,dev,test]"
 
 5. Install pre-commit checks::
 

--- a/django_virtual_models/serializers.py
+++ b/django_virtual_models/serializers.py
@@ -74,7 +74,9 @@ class VirtualModelSerializerMixin:
             "Using virtual models on %(cls_name)s. Finding lookup_list...",
             {"cls_name": cls_name},
         )
-        virtual_model_instance = virtual_model(user=self.get_request_user())
+        virtual_model_instance = virtual_model(
+            user=self.get_request_user(), serializer_context=self.context
+        )
         lookup_list = serializer_optimization.LookupFinder(
             serializer_instance=self,
             virtual_model=virtual_model_instance,

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -368,10 +368,10 @@ class VirtualUserMovieRating(v.VirtualModel):
     An advice: in general, you should avoid returning data relative to the current user in HTTP APIs, as this makes caching very hard or even impossible. Use this only if you really need it, as in a request that's only specific for users like user profile pages. Avoid nesting data related to the current user inside global data. Consider adding an additional request to fetch data relative to the current user, and then "hydrate" the previous request data on the frontend.
 
 
-### Using context of Serializer in Virtual Model
-In the same way that you can get the current user to generate the virtual model fields, it's possible to use any data that the view passes to the serializer by the context.
+### Using Serializer's context
+Similar to how `user` param works, it's possible to use in virtual models any data that the view passes to the serializer by context.
 
-Using the previous example, you might want to get the vote count equal than a specific number that is chosen in the view. To do this, use the serializer context to inform the number selected:
+Using the previous example, suppose you want to get the vote count equal to a specific value that is defined in the view. To do this, use the serializer context:
 
 ```python
 class MovieListView(v.VirtualModelListAPIView):

--- a/tests/virtual_model_serializers/test_virtual_model_serializers.py
+++ b/tests/virtual_model_serializers/test_virtual_model_serializers.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from rest_framework import serializers
+
+from model_bakery import baker
+
+import django_virtual_models as v
+
+from ..virtual_models.models import Course, User
+
+
+class VirtualModelSerializerTest(TestCase):
+    def test_pass_serializer_context_to_virtual_model(self):
+        class MockedVirtualCourse(v.VirtualModel):
+            something = v.Annotation(
+                lambda qs, user, **kwargs: qs.annotate_something(user=user, **kwargs)
+            )
+
+            class Meta:
+                model = Course
+                deferred_fields = ["name", "description", "something"]
+
+        class CourseSerializer(v.VirtualModelSerializer):
+            something = serializers.CharField()
+
+            class Meta:
+                model = Course
+                virtual_model = MockedVirtualCourse
+                fields = ["name", "description", "something"]
+
+        user = baker.make(User)
+        user.is_anonymous = False
+        request = MagicMock()
+        request.method = "GET"
+        request.user = user
+        serializer_context = {"request": request, "value": 12345}
+        mock_qs = MagicMock()
+        virtual_course_serializer = CourseSerializer(instance=None, context=serializer_context)
+        virtual_course_serializer.get_optimized_queryset(mock_qs)
+
+        mock_qs.annotate_something.assert_called_once_with(
+            user=user, serializer_context=serializer_context
+        )


### PR DESCRIPTION
Hello!
This PR is opened to implement the suggestion of issue #33 

How mentioned in the issue, the main change in the code was passes the serializer context to virtual model using a new param, that is catch by de `kwargs`:

        virtual_model_instance = virtual_model(
            user=self.get_request_user(), serializer_context=self.context
        )

https://github.com/jackson541/django-virtual-models/blob/ee215926e9ae5c093f7b25f630f9ce6ab8d03323/django_virtual_models/serializers.py#L77-L79

A new file of tests to Virtual Model Serializers was created to check this implementation.

Thanks for the attention! :smile: 