### PR TITLE
Updates supported versions of Python and Django

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+
+- Include `py.typed` file for type hints
+- Add support to Python 3.12 and 3.13
+- Drop support to Python 3.8 and 3.9
+- Add support to Django 5.0, 5.1, and 5.2
+- Drop support to Django 3.2, 4.0, and 4.1
+
 ## [0.2.0]
 
 - Add support to nested prefetch lookups like `v.VirtualModel(manager=User.objects, lookup="course__facilitators")`

--- a/django_virtual_models/__init__.py
+++ b/django_virtual_models/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for django_virtual_models."""
 import logging
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 # Good practice: https://docs.python-guide.org/writing/logging/#logging-in-a-library
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/django_virtual_models/query_capture/capture.py
+++ b/django_virtual_models/query_capture/capture.py
@@ -7,10 +7,20 @@ import inspect
 import time
 import typing
 from contextlib import ContextDecorator, ExitStack
-from distutils.sysconfig import get_python_lib
 
 from django.conf import settings
 from django.db import connection
+
+try:
+    from distutils.sysconfig import get_python_lib
+except ImportError:
+    from sysconfig import get_paths
+
+    def get_python_lib():
+        """
+        Get the path to the Python library directory.
+        """
+        return get_paths()["purelib"]
 
 
 class CapturedQuery(typing.TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "django >=3.2",
@@ -57,7 +57,7 @@ test = [
     "model_bakery >=1.11.0,<2.0.0",
 ]
 example = [
-    "django >= 3.2,<4.0",
+    "django >= 4.2,<6.0",
     "pyyaml >= 6.0,<7.0",
 ]
 
@@ -112,31 +112,31 @@ testpaths = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = {linux}-py{38,39,310,311}-django{32,40,41,42}
+envlist = {linux}-py{310,311,312,313}-django{42,50,51,52}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 OS =
     ubuntu-latest: linux
 DJANGO =
-    3.2: django32
-    4.0: django40
-    4.1: django41
     4.2: django42
+    5.0: django50
+    5.1: django51
+    5.2: django52
 
 [testenv]
 deps =
-    django32: django~=3.2
-    django40: django~=4.0
-    django41: django~=4.1
     django42: django~=4.2
+    django50: django~=5.0
+    django51: django~=5.1
+    django52: django~=5.2
     .[test]
 commands =
     coverage run -m pytest --basetemp={envtmpdir}


### PR DESCRIPTION
- Include `py.typed` file for type hints
- Add support to Python 3.12 and 3.13
- Drop support to Python 3.8 and 3.9
- Add support to Django 5.0, 5.1, and 5.2
- Drop support to Django 3.2, 4.0, and 4.1