### PR TITLE
Rename VirtualModel user field to avoid conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1]
+- Rename internal `user` attribute from `VirtualModel` to `_user` to avoid conflict with ForeignKey and OneToOneField fields with the same name
+
 ## [0.3.0]
 
 - Include `py.typed` file for type hints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1]
+## [0.4.0]
 - Rename internal `user` attribute from `VirtualModel` to `_user` to avoid conflict with ForeignKey and OneToOneField fields with the same name
 
 ## [0.3.0]

--- a/django_virtual_models/__init__.py
+++ b/django_virtual_models/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for django_virtual_models."""
 import logging
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 # Good practice: https://docs.python-guide.org/writing/logging/#logging-in-a-library
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/django_virtual_models/__init__.py
+++ b/django_virtual_models/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for django_virtual_models."""
 import logging
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 # Good practice: https://docs.python-guide.org/writing/logging/#logging-in-a-library
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/django_virtual_models/fields.py
+++ b/django_virtual_models/fields.py
@@ -199,7 +199,7 @@ class VirtualModel(BaseVirtualField, metaclass=VirtualModelMetaclass):
         if to_attr is not None and lookup is None:
             raise InvalidVirtualModelParams("Always provide a `lookup` when providing a `to_attr`")
 
-        self.user = user
+        self._user = user
         if manager is None:
             self.manager = self.Meta.model._default_manager
             self.model_cls = self.Meta.model
@@ -352,7 +352,7 @@ class VirtualModel(BaseVirtualField, metaclass=VirtualModelMetaclass):
         new_qs = self._hydrate_queryset_with_nested_declared_fields(
             qs=qs,
             lookup_list=new_lookup_list,
-            user=self.user,
+            user=self._user,
             **kwargs,
         )
         new_qs = _defer_fields(


### PR DESCRIPTION
Rename internal `user` attribute from `VirtualModel` to `_user` to avoid conflict with ForeignKey and OneToOneField fields with the same name

## Summary by Sourcery

Rename the internal `user` attribute in VirtualModel to `_user` to prevent naming conflicts with Django field names, bump the package version to 0.3.1, and update the changelog accordingly.

Bug Fixes:
- Rename internal `user` attribute to `_user` in VirtualModel to avoid conflicts with ForeignKey and OneToOneField names.

Documentation:
- Add version 0.3.1 entry to CHANGELOG outlining the rename.

Chores:
- Bump package version from 0.3.0 to 0.3.1.