### PR TITLE
doc: Fix minimal Django version requirement

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 ## Prerequisites
 
 - Python: <a href="https://pypi.org/project/django-virtual-models" target="_blank"><img src="https://img.shields.io/pypi/pyversions/django-virtual-models.svg?color=%2334D058" alt="Supported Python versions"></a>
-- Django >= 3.2
+- Django >= 4.2
 
 ## How to install
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Raise the documented minimal supported Django version from 3.2 to 4.2 in the prerequisites section